### PR TITLE
Fixes to PBS_Handler to make it just compare the numerical part of the job id

### DIFF
--- a/PerlLib/HPC/PBS_handler.pm
+++ b/PerlLib/HPC/PBS_handler.pm
@@ -81,8 +81,11 @@ sub job_running_or_pending_on_grid {
 
     foreach my $line (split(/\n/, $response)) {
         my @x = split(/\s+/, $line);
-
-        if ($x[0] eq $job_id) {
+	my $lcl_job_id = $x[0];
+	if ($x[0] =~ /(\d+)(\.[0-9a-zA-Z]*)*/) {
+	    $lcl_job_id = $1;
+	}
+        if ($lcl_job_id eq $job_id) {
             my $state = $x[4];
             
             $self->{job_id_to_submission_time}->{$job_id} = time();


### PR DESCRIPTION
Some PBS installations return more than just one extension to the job id, (i.e. 919778.pbs.scm)
during job submission and return a slightly different jobid when quired via qstat (i.e. 919778.pbs).
This patch fixes that by just comparing the numerical part of the jobid.
