### PR TITLE
Add missing semicolon to Farmit.pm

### DIFF
--- a/PerlLib/HPC/FarmIt.pm
+++ b/PerlLib/HPC/FarmIt.pm
@@ -86,7 +86,7 @@ sub new {
 
     umask(0000);
     
-    my $host = hostname
+    my $host = hostname;
     # required:
     my $cmds_list_aref = $params_href->{cmds} or confess "No commands specified";
     my $handler = $params_href->{handler} or confess "Need handler specified";


### PR DESCRIPTION
This is my first pull request, but the change seems pretty simple so here goes.
Line 89 doesn't have a semicolon at the end, and it causes an error because
hostname doesn't accept arguments anymore.
This just adds the missing semicolon.